### PR TITLE
Bugfix of error void-function sp-local-pair

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -49,11 +49,6 @@
 (defun common-lisp-sly/post-init-parinfer ()
   (add-hook 'lisp-mode-hook 'parinfer-mode))
 
-(defun common-lisp-sly/post-init-sly ()
-  ;; where do these belong?
-  (sp-local-pair '(sly-mrepl-mode) "'" "'" :actions nil)
-  (sp-local-pair '(sly-mrepl-mode) "`" "`" :actions nil))
-
 (defun common-lisp-sly/pre-init-evil ()
   (with-eval-after-load 'evil
     (when (configuration-layer/package-used-p 'sly)


### PR DESCRIPTION
Hello and thanks for maintaining this layer! :-)
I had an error on startup of emacs with this layer activated that sp-local-pair is a void-function.
Maybe I found the source of the error and deleted the suspicious function post-init-sly.
sp-local-pair seems to be a function of smartparens and is already configured there.